### PR TITLE
Add fixed version details to Maven scan logs

### DIFF
--- a/src/main/java/com/mycompany/xrayscan/XrayScanMojo.java
+++ b/src/main/java/com/mycompany/xrayscan/XrayScanMojo.java
@@ -146,12 +146,16 @@ public class XrayScanMojo extends AbstractMojo {
             return;
         }
         getLog().info("Liste des vulnérabilités :");
+        getLog().info("Colonnes : CVE | package | version | fixed-version | CVSS | sévérité");
         for (CveResult violation : violations) {
+            String fixedVersion = violation.getFixedVersion();
+            String fixedVersionColumn = (fixedVersion == null || fixedVersion.isBlank()) ? "-" : fixedVersion;
             getLog().info(String.format(Locale.ROOT,
-                    "%s | %s | %s | CVSS=%.1f | %s",
+                    "%s | %s | %s | %s | CVSS=%.1f | %s",
                     violation.getCveId(),
                     violation.getPackageName(),
                     violation.getVersion(),
+                    fixedVersionColumn,
                     violation.getCvssScore(),
                     violation.getSeverity()));
         }

--- a/src/main/java/com/mycompany/xrayscan/model/CveResult.java
+++ b/src/main/java/com/mycompany/xrayscan/model/CveResult.java
@@ -13,14 +13,22 @@ public class CveResult {
     private final double cvssScore;
     private final String severity;
     private final String summary;
+    private final String fixedVersion;
 
-    public CveResult(String cveId, String packageName, String version, double cvssScore, String severity, String summary) {
+    public CveResult(String cveId,
+                     String packageName,
+                     String version,
+                     double cvssScore,
+                     String severity,
+                     String summary,
+                     String fixedVersion) {
         this.cveId = cveId != null ? cveId : "";
         this.packageName = packageName != null ? packageName : "";
         this.version = version != null ? version : "";
         this.cvssScore = cvssScore;
         this.severity = severity != null ? severity : "";
         this.summary = summary != null ? summary : "";
+        this.fixedVersion = fixedVersion != null ? fixedVersion : "";
     }
 
     public String getCveId() {
@@ -47,6 +55,10 @@ public class CveResult {
         return summary;
     }
 
+    public String getFixedVersion() {
+        return fixedVersion;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -57,12 +69,13 @@ public class CveResult {
                 && Objects.equals(packageName, cveResult.packageName)
                 && Objects.equals(version, cveResult.version)
                 && Objects.equals(severity, cveResult.severity)
-                && Objects.equals(summary, cveResult.summary);
+                && Objects.equals(summary, cveResult.summary)
+                && Objects.equals(fixedVersion, cveResult.fixedVersion);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(cveId, packageName, version, cvssScore, severity, summary);
+        return Objects.hash(cveId, packageName, version, cvssScore, severity, summary, fixedVersion);
     }
 
     @Override
@@ -74,6 +87,7 @@ public class CveResult {
                 ", cvssScore=" + cvssScore +
                 ", severity='" + severity + '\'' +
                 ", summary='" + summary + '\'' +
+                ", fixedVersion='" + fixedVersion + '\'' +
                 '}';
     }
 }

--- a/src/test/java/com/mycompany/xrayscan/XrayScanMojoTest.java
+++ b/src/test/java/com/mycompany/xrayscan/XrayScanMojoTest.java
@@ -49,7 +49,7 @@ class XrayScanMojoTest {
                         .withHeader("Content-Type", "application/json")
                         .withBody("{\"violations\":[{" +
                                 "\"cve\":\"CVE-2024-0001\"," +
-                                "\"components\":[{\"name\":\"log4j-core\",\"version\":\"2.19.0\"}]," +
+                                "\"components\":[{\"name\":\"log4j-core\",\"version\":\"2.19.0\",\"fixed_versions\":[\"2.19.1\"]}]," +
                                 "\"cvss_score\":6.5," +
                                 "\"severity\":\"Medium\"," +
                                 "\"summary\":\"Test vulnerability\"}]}")));
@@ -64,6 +64,7 @@ class XrayScanMojoTest {
         assertThat(results.isArray()).isTrue();
         assertThat(results.size()).isEqualTo(1);
         assertThat(results.get(0).path("cvssScore").asDouble()).isEqualTo(6.5);
+        assertThat(results.get(0).path("fixedVersion").asText()).isEqualTo("2.19.1");
     }
 
     @Test
@@ -75,7 +76,7 @@ class XrayScanMojoTest {
                         .withHeader("Content-Type", "application/json")
                         .withBody("{\"violations\":[{" +
                                 "\"cve\":\"CVE-2024-9999\"," +
-                                "\"components\":[{\"name\":\"commons-io\",\"version\":\"2.6\"}]," +
+                                "\"components\":[{\"name\":\"commons-io\",\"version\":\"2.6\",\"fixed_versions\":[\"2.7\"]}]," +
                                 "\"cvss_score\":9.1," +
                                 "\"severity\":\"Critical\"," +
                                 "\"summary\":\"Critical vulnerability\"}]}")));


### PR DESCRIPTION
## Summary
- enrich the CveResult model with the fixed version field and expose it throughout the report
- extract fixed version data from Xray responses and display it in Maven logs with a dedicated column
- update plugin tests to cover the new fixed version information in generated reports

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68ddf7d96a34833385bd0201683d7c7a